### PR TITLE
Two fixes to the automatic flight system

### DIFF
--- a/Nasal/systems.nas
+++ b/Nasal/systems.nas
@@ -294,6 +294,31 @@ setlistener("sim/signals/fdm-initialized", func {
 	settimer(instruments.loop, 2);
 });
 
+## AUTOMATIC A/T KTS/MACH SWITCHING
+###################################
+
+var prevAlt = 0;
+var atKtsMachLoop = func {
+    var alt = math.floor(getprop("instrumentation/altimeter/indicated-altitude-ft"));
+    if (alt >= 29000 and prevAlt < 29000) {
+        # switch to Mach
+        var mach = getprop("instrumentation/airspeed-indicator/indicated-mach");
+        setprop("it-autoflight/input/spd-mach", mach);
+        setprop("it-autoflight/input/kts-mach", 1);
+    }
+    if (alt < 28900 and prevAlt >= 28900) {
+        # switch to IAS
+        var kts = getprop("instrumentation/airspeed-indicator/indicated-speed-kt");
+        setprop("it-autoflight/input/spd-kts", kts);
+        setprop("it-autoflight/input/kts-mach", 0);
+    }
+    prevAlt = alt;
+    settimer(atKtsMachLoop, 2);
+};
+setlistener("sim/signals/fdm-initialized", func {
+    settimer(atKtsMachLoop, 2);
+});
+
 ## AUTOPILOT
 ############
 

--- a/XMLs/FlightDeck/erj.flightdeck.xml
+++ b/XMLs/FlightDeck/erj.flightdeck.xml
@@ -1084,16 +1084,44 @@
 <!-- FLCH -->
 
     <animation>
+        <!-- if current mode is already FLCH, revert to FPA -->
         <type>pick</type>
         <object-name>FLCH</object-name>
+        <condition>
+            <equals>
+                <property>it-autoflight/output/vert</property>
+                <value>4</value>
+            </equals>
+        </condition>
         <action>
             <button>0</button>
             <repeatable type="bool">false</repeatable>
             <binding>
-                <command>property-cycle</command>
+                <command>property-assign</command>
+                <property>it-autoflight/input/vert</property>
+                <value>5</value>
+            </binding>
+        </action>
+    </animation>
+    <animation>
+        <!-- if current mode is not FLCH, set FLCH -->
+        <type>pick</type>
+        <object-name>FLCH</object-name>
+        <condition>
+            <not>
+                <equals>
+                    <property>it-autoflight/output/vert</property>
+                    <value>4</value>
+                </equals>
+            </not>
+        </condition>
+        <action>
+            <button>0</button>
+            <repeatable type="bool">false</repeatable>
+            <binding>
+                <command>property-assign</command>
                 <property>it-autoflight/input/vert</property>
                 <value>4</value>
-                <value>5</value>
             </binding>
         </action>
     </animation>
@@ -1102,7 +1130,7 @@
         <object-name>FLCH.light</object-name>
         <condition>
             <equals>
-                <property>it-autoflight/input/vert</property>
+                <property>it-autoflight/output/vert</property>
                 <value>4</value>
             </equals>
         </condition>


### PR DESCRIPTION
- FLCH button now works correctly (previously requires pressing twice to actually engage FLCH mode sometimes)
- SPD selection automatically switches between kts and Mach when crossing FL290