### PR TITLE
A few more improvements

### DIFF
--- a/ERJ-set-common.xml
+++ b/ERJ-set-common.xml
@@ -84,6 +84,10 @@
 				<path>Aircraft/E-jet-family/Systems/ERJ-autobrake.xml</path>
 			</autopilot>
 			<autopilot>
+				<name>Trust Rating System</name>
+				<path>Aircraft/E-jet-family/Systems/ERJ-trs.xml</path>
+			</autopilot>
+			<autopilot>
 				<name>Gear AGL Altitude</name>
 				<path>Aircraft/E-jet-family/Systems/gear-agl-ft.xml</path>
 			</autopilot>
@@ -274,6 +278,14 @@
 							<dialog-name>tiller-dlg</dialog-name>
 						</binding>
 					</item>
+					<item>
+						<name>performance</name>
+						<label>Performance Config</label>
+						<binding>
+							<command>dialog-show</command>
+							<dialog-name>performance</dialog-name>
+						</binding>
+					</item>
 				</menu>
 			</default>
 		</menubar>
@@ -382,7 +394,7 @@
 			<auto-bank-max-deg>35</auto-bank-max-deg> <!-- Maximum Auto Bank Limit -->
 			<land-enable>1</land-enable> <!-- Enable/Disable Autoland -->
 			<land-flap>0.5</land-flap> <!-- Minimum Flap used for Landing -->
-			<retard-ft>50</retard-ft> <!-- Enable Thrust Retard -->
+			<retard-ft>30</retard-ft> <!-- Enable Thrust Retard -->
 			<retard-enable>1</retard-enable> <!-- AGL to Thrust Retard -->
 			<togaspd>165</togaspd> <!-- V2 + 10kts -->
 			<lat-agl-ft>200</lat-agl-ft> <!-- Set to 999999 if you do not want T/O to change automatically to HDG, or LNAV -->
@@ -446,6 +458,10 @@
 		<autothrottle-serviceable type="bool">true</autothrottle-serviceable>
 		<yaw-damper-serviceable type="bool">true</yaw-damper-serviceable>
 	</autopilot>
+
+    <trs>
+        <phase type="int">0</phase>
+    </trs>
 
 	<controls>
 		<anti-ice>
@@ -522,6 +538,12 @@
 		<flight>
 			<ground-spoilers-armed type="bool">false</ground-spoilers-armed>
 			<speedbrake-lever type="double">0</speedbrake-lever>
+            <thrust-toga type="double">97.0</thrust-toga>
+            <thrust-flex type="bool">true</thrust-flex>
+            <thrust-climb1 type="double">87.6</thrust-climb1>
+            <thrust-climb2 type="double">78.2</thrust-climb2>
+            <thrust-con type="double">90.8</thrust-con>
+            <thrust-crz type="double">73.5</thrust-crz>
 		</flight>
 
 		<gear>

--- a/Models/Primus-Epic/PFD.nas
+++ b/Models/Primus-Epic/PFD.nas
@@ -605,7 +605,12 @@ var canvas_ED_only = {
 
 		me["fma.lat"].setText(latModeMap[me.props["/it-autoflight/mode/lat"].getValue() or ""] or "");
 		me["fma.vert"].setText(vertModeMap[me.props["/it-autoflight/mode/vert"].getValue() or ""] or "");
-		me["fma.vertarmed"].setText(vertModeArmedMap[me.props["/it-autoflight/mode/vert"].getValue() or ""] or "");
+        if (me.props["/it-autoflight/output/appr-armed"].getValue() and me.props["/it-autoflight/mode/vert"].getValue != "G/S") {
+            me["fma.vertarmed"].setText("GS");
+        }
+        else {
+            me["fma.vertarmed"].setText(vertModeArmedMap[me.props["/it-autoflight/mode/vert"].getValue() or ""] or "");
+        }
 		me["fma.spd"].setText(
 				spdModeMap[me.props["/it-autoflight/mode/vert"].getValue() or ""] or
 				spdModeMap[me.props["/it-autoflight/mode/thr"].getValue() or ""] or
@@ -628,6 +633,21 @@ var canvas_ED_only = {
 		else {
 			me["fma.latarmed"].setText(latModeArmedMap[me.props["/it-autoflight/mode/arm"].getValue()]);
 		}
+        # show APPR2 arm when approach armed
+        if (me.props["/it-autoflight/output/appr-armed"].getValue() or
+            me.props["/it-autoflight/mode/lat"].getValue() == "LOC") {
+            me["fma.apprarmed"].show();
+            if (radarAlt <= 1500) {
+                me["fma.appr"].show();
+            }
+            else {
+                me["fma.appr"].hide();
+            }
+        }
+        else {
+            me["fma.appr"].hide();
+            me["fma.apprarmed"].hide();
+        }
 	},
 };
 

--- a/Nasal/dialogs.nas
+++ b/Nasal/dialogs.nas
@@ -6,6 +6,7 @@ var Dialogs = {
 	operations: gui.Dialog.new("sim/gui/dialogs/E-jet-family[0]/menu/dialog", aircraft_path~"operations-dlg.xml"),
 	radio: gui.Dialog.new("sim/gui/dialogs/radios/dialog", aircraft_path~"radio.xml"),
 	tiller: gui.Dialog.new("sim/gui/dialogs/tiller/dialog", aircraft_path~"tiller-dlg.xml"),
+	performance: gui.Dialog.new("sim/gui/dialogs/performance/dialog", aircraft_path~"performance-dlg.xml"),
 	
 };
 

--- a/Systems/ERJ-spoilers.xml
+++ b/Systems/ERJ-spoilers.xml
@@ -1,25 +1,50 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+ml version="1.0" encoding="UTF-8" ?>
 
-<!-- Airbus A330 speedbrake/ground spoiler configuration -->
+<!-- Embraer E-Jet speedbrake/ground spoiler configuration -->
 
 <PropertyList>
 
-	<logic>
-		<name>Ground spoilers disarm</name>
-		<enable>
-			<condition>
+	<flipflop>
+		<name>Ground spoilers arm/disarm</name>
+		<debug type="bool">true</debug>
+		<type>RS</type>
+		<S>
+			<and>
+				<!-- Ground spoilers can only be armed when the speedbrake lever is up -->
+				<equals>
+					<property>/controls/flight/speedbrake-lever</property>
+					<value>0</value>
+				</equals>
+				<!-- ...and flaps are set to 5 or FULL -->
+				<greater-than>
+					<property>/controls/flight/flaps</property>
+					<value>0.5</value>
+				</greater-than>
+				<!-- ...and the aircraft is not on the ground yet. -->
+				<not><property>/gear/gear[1]/wow</property></not>
+				<not><property>/gear/gear[2]/wow</property></not>
+			</and>
+		</S>
+		<R>
+			<or>
 				<!-- Ground spoilers can only be armed when the speedbrake lever is up -->
 				<greater-than>
 					<property>/controls/flight/speedbrake-lever</property>
 					<value>0</value>
 				</greater-than>
-			</condition>
-		</enable>
-		<input>
-			<false />
-		</input>
+				<!-- ...and flaps are set to 5 or FULL -->
+				<less-than>
+					<property>/controls/flight/flaps</property>
+					<value>0.5</value>
+				</less-than>
+				<less-than>
+					<property>/instrumentation/airspeed-indicator/indicated-speed-kt</property>
+					<value>40</value>
+				</less-than>
+			</or>
+		</R>
 		<output>/controls/flight/ground-spoilers-armed</output>
-	</logic>
+	</flipflop>
 
 	<logic>
 		<name>Ground spoilers engage</name>

--- a/Systems/ERJ-trs.xml
+++ b/Systems/ERJ-trs.xml
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!-- Embraer 190 AOM page 1478 -->
+
+<!-- Phases
+	0 TO
+	1 GA
+	2 CLB1
+	3 CLB2
+	4 CRZ
+	5 CON
+-->
+
+<PropertyList>
+
+<filter>
+	<name>Altitude error</name>
+	<type>gain</type>
+	<input>
+		<expression>
+			<difference>
+				<property>/instrumentation/altimeter/indicated-altitude-ft</property>
+				<property>/it-autoflight/internal/alt</property>
+			</difference>
+		</expression>
+	</input>
+	<output>/trs/altitude-error</output>
+</filter>
+
+<filter>
+	<name>Airspeed error</name>
+	<type>gain</type>
+	<gain>1</gain>
+	<input>
+		<expression>
+			<difference>
+				<property>/instrumentation/airspeed-indicator/indicated-speed-kt</property>
+				<property>/it-autoflight/input/spd-kts</property>
+			</difference>
+		</expression>
+	</input>
+	<output>/trs/airspeed-error-kts</output>
+</filter>
+
+<filter>
+	<name>Mach error</name>
+	<type>gain</type>
+	<!-- normalize such that mach .01 corresponds to 5 kts normalized -->
+	<gain>500</gain>
+	<input>
+		<expression>
+			<difference>
+				<property>/instrumentation/airspeed-indicator/indicated-mach</property>
+				<property>/it-autoflight/input/spd-mach</property>
+			</difference>
+		</expression>
+	</input>
+	<output>/trs/airspeed-error-mach</output>
+</filter>
+
+<filter>
+	<name>Normalized airspeed error</name>
+	<type>gain</type>
+	<gain>1</gain>
+	<input>
+		<condition>
+			<property>/it-autoflight/input/kts-mach</property>
+		</condition>
+		<property>/trs/airspeed-error-mach</property>
+	</input>
+	<input>
+		<property>/trs/airspeed-error-kts</property>
+	</input>
+	<output>/trs/airspeed-error</output>
+</filter>
+
+<flipflop>
+	<name>90-second cruise detection</name>
+	<type>monostable</type>
+	<inverted type="bool">true</inverted>
+	<time><value>90.0</value></time>
+	<J>
+		<and>
+			<greater-than>
+				<property>/trs/altitude-error</property>
+				<value>-10</value>
+			</greater-than>
+			<greater-than>
+				<property>/trs/airspeed-error</property>
+				<value>-5</value>
+			</greater-than>
+		</and>
+	</J>
+	<S>
+		<or>
+			<less-than>
+				<property>/trs/altitude-error</property>
+				<value>-10</value>
+			</less-than>
+			<less-than>
+				<property>/trs/airspeed-error</property>
+				<value>-5</value>
+			</less-than>
+		</or>
+	</S>
+	<output>/trs/crz-90sec</output>
+</flipflop>
+
+<filter>
+	<name>Flight phase logic</name>
+	<type>gain</type>
+	<gain>1</gain>
+	<input>
+		<condition>
+			<equals>
+				<property>/it-autoflight/mode/vert</property>
+				<value>T/O CLB</value>
+			</equals>
+		</condition>
+		<value>0</value>
+	</input>
+	<input>
+		<condition>
+			<greater-than>
+				<property>/gear/gear[1]/position-norm</property>
+				<value>0</value>
+			</greater-than>
+		</condition>
+		<value>1</value>
+	</input>
+	<input>
+		<condition>
+			<not>
+				<and>
+					<property>/engines/engine[0]/running</property>
+					<property>/engines/engine[1]/running</property>
+				</and>
+			</not>
+		</condition>
+		<value>5</value>
+	</input>
+	<input>
+		<condition>
+			<property>/trs/crz-90sec</property>
+		</condition>
+		<value>4</value>
+	</input>
+	<input>
+		<condition>
+			<and>
+				<or>
+					<and>
+						<not>
+							<equals>
+								<property>/it-autoflight/mode/vert</property>
+								<value>T/O CLB</value>
+							</equals>
+						</not>
+						<property>/it-autoflight/output/ap1</property>
+						<greater-than>
+							<property>/position/gear-agl-ft</property>
+							<value>400</value>
+						</greater-than>
+					</and>
+					<greater-than>
+						<property>/position/gear-agl-ft</property>
+						<value>3000</value>
+					</greater-than>
+				</or>
+				<equals>
+					<property>/gear/gear[0]/position-norm</property>
+					<value>0</value>
+				</equals>
+				<equals>
+					<property>/gear/gear[1]/position-norm</property>
+					<value>0</value>
+				</equals>
+				<equals>
+					<property>/gear/gear[2]/position-norm</property>
+					<value>0</value>
+				</equals>
+				<less-than>
+					<property>/trs/altitude-error</property>
+					<value>50</value>
+				</less-than>
+			</and>
+		</condition>
+		<value>2</value>
+	</input>
+	<input>
+		<value>5</value>
+	</input>
+	<output>/trs/phase</output>
+</filter>
+
+<!-- forwarding thrust limit to A/T -->
+<filter>
+	<name>Forward thrust to ITAF</name>
+	<type>gain</type>
+	<gain>0.01</gain>
+	<input>
+		<condition>
+			<equals>
+				<property>/trs/phase</property>
+				<value>0</value>
+			</equals>
+		</condition>
+		<property>/controls/flight/thrust-toga</property>
+	</input>
+	<input>
+		<condition>
+			<equals>
+				<property>/trs/phase</property>
+				<value>1</value>
+			</equals>
+		</condition>
+		<property>/controls/flight/thrust-toga</property>
+	</input>
+	<input>
+		<condition>
+			<equals>
+				<property>/trs/phase</property>
+				<value>2</value>
+			</equals>
+		</condition>
+		<property>/controls/flight/thrust-climb1</property>
+	</input>
+	<input>
+		<condition>
+			<equals>
+				<property>/trs/phase</property>
+				<value>3</value>
+			</equals>
+		</condition>
+		<property>/controls/flight/thrust-climb2</property>
+	</input>
+	<input>
+		<condition>
+			<equals>
+				<property>/trs/phase</property>
+				<value>4</value>
+			</equals>
+		</condition>
+		<property>/controls/flight/thrust-crz</property>
+	</input>
+	<input>
+		<condition>
+			<equals>
+				<property>/trs/phase</property>
+				<value>5</value>
+			</equals>
+		</condition>
+		<property>/controls/flight/thrust-con</property>
+	</input>
+	<output>/it-autoflight/settings/autothrottle-max</output>
+</filter>
+
+</PropertyList>

--- a/Systems/performance-dlg.xml
+++ b/Systems/performance-dlg.xml
@@ -155,7 +155,7 @@
                     <pref-width>60</pref-width>
                 </text>
                 <input>
-                    <property>/controls/flight/thrust-con</property>
+                    <property>/controls/flight/thrust-crz</property>
                     <label>%N1</label>
                 </input>
             </group>

--- a/Systems/performance-dlg.xml
+++ b/Systems/performance-dlg.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0"?>
+<PropertyList>
+    <name>performance</name>
+	<layout>vbox</layout>
+	<pref-width>600</pref-width>
+
+    <group>
+        <layout>hbox</layout>
+		<empty>
+			<stretch>1</stretch>
+		</empty>
+
+        <text>
+            <label>Performance</label>
+        </text>
+
+		<empty>
+			<stretch>1</stretch>
+		</empty>
+
+		<button>
+			<pref-width>16</pref-width>
+			<pref-height>16</pref-height>
+			<legend></legend>
+			<keynum>27</keynum>
+			<border>2</border>
+			<binding>
+				<command>dialog-close</command>
+			</binding>
+		</button>
+    </group>
+
+    <hrule/>
+
+    <group>
+        <layout>hbox</layout>
+
+        <group>
+            <layout>vbox</layout>
+            <halign>center</halign>
+            <valign>top</valign>
+
+            <text>
+                <label>Speed References</label>
+            </text>
+            <group>
+                <layout>hbox</layout>
+                <text>
+                    <label>V1</label>
+                    <pref-width>30</pref-width>
+                </text>
+                <input>
+                    <property>/controls/flight/v1</property>
+                    <label>KIAS</label>
+                </input>
+            </group>
+            <group>
+                <layout>hbox</layout>
+                <text>
+                    <label>Vr</label>
+                    <pref-width>30</pref-width>
+                </text>
+                <input>
+                    <property>/controls/flight/vr</property>
+                    <label>KIAS</label>
+                </input>
+            </group>
+            <group>
+                <layout>hbox</layout>
+                <text>
+                    <label>V2</label>
+                    <pref-width>30</pref-width>
+                </text>
+                <input>
+                    <property>/controls/flight/v2</property>
+                    <label>KIAS</label>
+                </input>
+            </group>
+            <group>
+                <layout>hbox</layout>
+                <text>
+                    <label>Vref</label>
+                    <pref-width>30</pref-width>
+                </text>
+                <input>
+                    <property>/controls/flight/vref</property>
+                    <label>KIAS</label>
+                </input>
+            </group>
+
+        </group>
+        <group>
+            <layout>vbox</layout>
+            <halign>center</halign>
+            <valign>top</valign>
+            <text>
+                <label>Thrust Ratings</label>
+            </text>
+            <group>
+                <layout>hbox</layout>
+                <text>
+                    <label>TOGA</label>
+                    <pref-width>60</pref-width>
+                </text>
+                <input>
+                    <property>/controls/flight/thrust-toga</property>
+                    <label>%N1</label>
+                </input>
+            </group>
+            <group>
+                <layout>hbox</layout>
+                <checkbox>
+                    <label>Flex T/O</label>
+                    <property>/controls/flight/thrust-flex</property>
+                    <halign>left</halign>
+                </checkbox>
+            </group>
+            <group>
+                <layout>hbox</layout>
+                <text>
+                    <label>CON</label>
+                    <pref-width>60</pref-width>
+                </text>
+                <input>
+                    <property>/controls/flight/thrust-con</property>
+                    <label>%N1</label>
+                </input>
+            </group>
+            <group>
+                <layout>hbox</layout>
+                <text>
+                    <label>CLB1</label>
+                    <pref-width>60</pref-width>
+                </text>
+                <input>
+                    <property>/controls/flight/thrust-climb1</property>
+                    <label>%N1</label>
+                </input>
+            </group>
+            <group>
+                <layout>hbox</layout>
+                <text>
+                    <label>CLB2</label>
+                    <pref-width>60</pref-width>
+                </text>
+                <input>
+                    <property>/controls/flight/thrust-climb2</property>
+                    <label>%N1</label>
+                </input>
+            </group>
+            <group>
+                <layout>hbox</layout>
+                <text>
+                    <label>CRZ</label>
+                    <pref-width>60</pref-width>
+                </text>
+                <input>
+                    <property>/controls/flight/thrust-con</property>
+                    <label>%N1</label>
+                </input>
+            </group>
+        </group>
+
+    </group>
+    <hrule/>
+
+    <button>
+        <legend>Apply</legend>
+        <binding>
+            <command>dialog-apply</command>
+        </binding>
+    </button>
+
+</PropertyList>
+


### PR DESCRIPTION
- Ground spoilers working again
- PFD now shows APPR2 annunciations only when actually on an approach (TODO: cannot distinguish between APPR1 and APPR2 yet...)
- TRS (Trust Rating System): the autothrottle is now automatically limited based on flight phase, and the ratings can be overridden in a dialog (FLEX TO does not work yet though, and will use regular TOGA instead).